### PR TITLE
Add depends to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     description="Simple Jupyter extension to use interact.",
     packages=setuptools.find_packages(),
     install_requires=[
-        'notebook',
+        'notebook', 'pytest', 'webargs', 'requests', 'gitpython', 'toolz'
     ],
     package_data={'nbinteract': ['static/*']},
 )


### PR DESCRIPTION
The data-8 user image script install-extensions.bash says
that nbinteract depends on these libraries with the comment,
"FIXME: This should just be in setup.py of the repo".