### PR TITLE
Allow specifying domain name and github account name

### DIFF
--- a/nbinteract/config.py
+++ b/nbinteract/config.py
@@ -59,6 +59,8 @@ class Config(object):
     # This is the url that will be shown to the user if an error occurs
     ERROR_REDIRECT_URL = os.environ.get('ERROR_REDIRECT_URL', default='')
 
+    ALLOWED_URL_DOMAIN = []
+
     def __getitem__(self, attr):
         """
         Temporary hack in order to maintain Flask config-like config usage.
@@ -90,7 +92,12 @@ class ProductionConfig(Config):
     GIT_REDIRECT_PATH = '/user/{username}/tree/{destination}'
 
     # alowed file extensions
-    ALLOWED_FILETYPES = ['ipynb']
+    ALLOWED_FILETYPES = os.environ.get(
+        'ALLOWED_FILETYOES', default="ipynb").split(Config.DELIMITER)
+
+    # allowed direct url download from domain
+    ALLOWED_URL_DOMAIN = os.environ.get(
+        'ALLOWED_URL_DOMAIN', default="").split(Config.DELIMITER)
 
 
 class DevelopmentConfig(Config):
@@ -121,7 +128,7 @@ class DevelopmentConfig(Config):
     GIT_REDIRECT_PATH = '/tree/home/{destination}'
 
     # allowed sources for file parameter in query
-    ALLOWED_DOMAIN = 'http://localhost:8000'
+    ALLOWED_URL_DOMAIN = 'http://localhost:8000'
 
     # base_url for the program
     BASE_URL = 'http://localhost:8002'
@@ -164,7 +171,7 @@ class TestConfig(Config):
     GIT_REDIRECT_PATH = None
 
     # allowed sources for file parameter in query
-    ALLOWED_DOMAIN = 'http://localhost:8000'
+    ALLOWED_URL_DOMAIN = 'http://localhost:8000'
 
     # base_url for the program
     BASE_URL = 'http://localhost:8002'

--- a/nbinteract/config.py
+++ b/nbinteract/config.py
@@ -82,8 +82,8 @@ class ProductionConfig(Config):
     # username of user
     USERNAME = os.environ.get('JPY_USER', default='jovyan')
 
-    # where file is copied to
-    COPY_PATH = ''
+    # where file is copied to, by default use current dir
+    COPY_PATH = os.path.realpath('.')
 
     # where users are redirected upon file download success
     FILE_REDIRECT_PATH = '/user/{username}/notebooks/{destination}'
@@ -93,7 +93,7 @@ class ProductionConfig(Config):
 
     # alowed file extensions
     ALLOWED_FILETYPES = os.environ.get(
-        'ALLOWED_FILETYOES', default="ipynb").split(Config.DELIMITER)
+        'ALLOWED_FILETYPES', default="ipynb").split(Config.DELIMITER)
 
     # allowed direct url download from domain
     ALLOWED_URL_DOMAIN = os.environ.get(

--- a/nbinteract/config.py
+++ b/nbinteract/config.py
@@ -26,19 +26,30 @@ class Config(object):
 
     PORT = 8002
 
+    DELIMITER = ':'
+
     # Note: we use environ.get becauase all of these statements get run in
     # every environment, so os.environ['FOOBAR'] will throw an error in
     # development.
 
     # Github API token; used to pull private repos
     GITHUB_API_TOKEN = os.environ.get('GITHUB_API_TOKEN', default='')
+    GITHUB_DOMAIN = 'github.com'
 
-    # The organization URL on Github. The API token is filled in so that
-    # private repos can be pulled
-    GITHUB_ORG = 'https://{}@github.com/data-8/'.format(GITHUB_API_TOKEN)
+    # Default domain to pull from is Github
+    DEFAULT_DOMAIN = GITHUB_DOMAIN
+
+    # A list of domain that can pull from, delimited by DELIMITER
+    ALLOWED_WEB_DOMAINS = os.environ.get(
+        'ALLOWED_WEB_DOMAINS', default=GITHUB_DOMAIN).split(DELIMITER)
+
+    # The default and allowed github account(s) that will be pulled from
+    # , used only with github.com
+    DEFAULT_GITHUB_ACCOUNT = 'data-8'
+    ALLOWED_GITHUB_ACCOUNTS = os.environ.get(
+        'ALLOWED_GITHUB_ACCOUNTS', default=DEFAULT_GITHUB_ACCOUNT).split(DELIMITER)
 
     # The branch that will be pulled in
-    DEFAULT_REPO_BRANCH = 'gh-pages'
     DEFAULT_BRANCH_NAME = 'gh-pages'
 
     # Timeout for authentication token retrieval. Used when checking if

--- a/nbinteract/download_file_and_redirect.py
+++ b/nbinteract/download_file_and_redirect.py
@@ -1,6 +1,7 @@
 import os
 from urllib.error import HTTPError
 from urllib.request import urlopen
+import urllib.parse as urlparse
 
 from . import util
 from . import messages
@@ -43,21 +44,23 @@ def download_file_and_redirect(**kwargs):
                  .format(file_url))
         util.logger.exception(error)
         return messages.error({
-                'message': error,
-                'proceed_url': config['ERROR_REDIRECT_URL']
-            })
+            'message': error,
+            'proceed_url': config['ERROR_REDIRECT_URL']
+        })
     except Exception as e:
         error = ('Unhandled error: {}'.format(e))
         util.logger.exception(error)
         return messages.error({
-                'message': error,
-                'proceed_url': config['ERROR_REDIRECT_URL']
-            })
+            'message': error,
+            'proceed_url': config['ERROR_REDIRECT_URL']
+        })
 
 
 def _get_remote_file(config, source):
     """Fetches file, throws an HTTPError if the file is not accessible."""
-    if not source.startswith(config['ALLOWED_DOMAIN']):
+    url_components = urlparse.urlparse(source)
+
+    if url_components.netloc not in config['ALLOWED_URL_DOMAIN']:
         raise ValueError('File not from allowed domain')
 
     return urlopen(source).read().decode('utf-8')

--- a/nbinteract/handlers.py
+++ b/nbinteract/handlers.py
@@ -30,7 +30,7 @@ from .config import Config
 thread_pool = ThreadPoolExecutor(max_workers=4)
 
 url_args = {
-    'file': fields.Str(),
+    'file_url': fields.Str(),
     'domain': fields.Str(),
     'account': fields.Str(),
     'repo': fields.Str(),
@@ -47,9 +47,11 @@ class LandingHandler(RequestHandler):
     Option 1
     --------
 
-        ?file=public_file_url
+        ?file_url=public_file_url
 
     Example: ?file=http://localhost:8000/README.md
+
+    The domain in the url must be included in the whitelist in config
 
     Downloads file into user's system.
 
@@ -64,7 +66,7 @@ class LandingHandler(RequestHandler):
     """
     @use_args(url_args)
     def get(self, args):
-        is_file_request = ('file' in args)
+        is_file_request = ('file_url' in args)
         # branch name can be omitted for default value
         is_git_request = ('repo' in args and 'path' in args)
         valid_request = xor(is_file_request, is_git_request)
@@ -107,14 +109,14 @@ class RequestHandler(WebSocketHandler):
 
         # We don't do validation since we assume that the LandingHandler did
         # it. TODO: ENHANCE SECURITY
-        is_file_request = ('file' in args)
+        is_file_request = ('file_url' in args)
 
         try:
             if is_file_request:
                 message = yield thread_pool.submit(
                     download_file_and_redirect,
                     username=username,
-                    file_url=args['file'],
+                    file_url=args['file_url'],
                     config=options.config,
                 )
             else:

--- a/nbinteract/handlers.py
+++ b/nbinteract/handlers.py
@@ -24,7 +24,7 @@ from . import messages
 from . import util
 from .download_file_and_redirect import download_file_and_redirect
 from .git_progress import Progress
-from nbinteract import pull_from_remote
+from .pull_from_remote import pull_from_remote
 from .config import Config
 
 thread_pool = ThreadPoolExecutor(max_workers=4)

--- a/nbinteract/handlers.py
+++ b/nbinteract/handlers.py
@@ -49,7 +49,7 @@ class LandingHandler(RequestHandler):
 
         ?file_url=public_file_url
 
-    Example: ?file=http://localhost:8000/README.md
+    Example: ?file_url=http://localhost:8000/README.md
 
     The domain in the url must be included in the whitelist in config
 

--- a/nbinteract/pull_from_remote.py
+++ b/nbinteract/pull_from_remote.py
@@ -7,6 +7,17 @@ from . import util
 from . import messages
 
 
+def _generate_repo_url(scheme, domain, account, repo_name, auth_token=''):
+    netloc = None
+    if auth_token:
+        netloc = domain
+    else:
+        netloc = auth_token + '%' + domain
+    if account:
+        account += '/'
+    return "%s://%s/%s%s" % (scheme, netloc, account, repo_name)
+
+
 def pull_from_remote(**kwargs):
     """
     Initializes git repo if needed, then pulls new content from remote repo using
@@ -81,9 +92,8 @@ def pull_from_remote(**kwargs):
 
     # Retrieve file form the git repository
     repo_dir = util.construct_path(notebook_path, locals(), repo_name)
-
+    repo_url = ''
     # Generate repo url
-    repo_url = "https://"
     if domain not in config['ALLOWED_WEB_DOMAINS']:
         return messages.error({
             'message': "Specified domain " + domain + " is not allowed.",
@@ -95,12 +105,11 @@ def pull_from_remote(**kwargs):
                 'message': "Specified github account " + account + " is not allowed.",
                 'proceed_url': config['ERROR_REDIRECT_URL']
             })
-        repo_url += "{}@".format(config['GITHUB_API_TOKEN']) + \
-            domain + "/" + \
-            account + '/' + \
-            repo_name
+        repo_url += _generate_repo_url("https", domain,
+                                       account, repo_name, config['GITHUB_API_TOKEN'])
     else:
-        repo_url += domain + "/" + repo_name
+        repo_url += _generate_repo_url("https",
+                                       domain, '', repo_name)
 
     try:
         if not os.path.exists(repo_dir):

--- a/nbinteract/pull_from_remote.py
+++ b/nbinteract/pull_from_remote.py
@@ -5,7 +5,6 @@ import git
 
 from . import util
 from . import messages
-from .config import Config
 
 
 def pull_from_remote(**kwargs):
@@ -85,18 +84,18 @@ def pull_from_remote(**kwargs):
 
     # Generate repo url
     repo_url = "https://"
-    if domain not in Config.ALLOWED_WEB_DOMAINS:
+    if domain not in config['ALLOWED_WEB_DOMAINS']:
         return messages.error({
             'message': "Specified domain " + domain + " is not allowed.",
             'proceed_url': config['ERROR_REDIRECT_URL']
         })
-    if domain == Config.GITHUB_DOMAIN:
-        if account not in Config.ALLOWED_GITHUB_ACCOUNTS:
+    if domain == config['GITHUB_DOMAIN']:
+        if account not in config['ALLOWED_GITHUB_ACCOUNTS']:
             return messages.error({
                 'message': "Specified github account " + account + " is not allowed.",
                 'proceed_url': config['ERROR_REDIRECT_URL']
             })
-        repo_url += "{}@".format(Config.GITHUB_API_TOKEN) + \
+        repo_url += "{}@".format(config['GITHUB_API_TOKEN']) + \
             domain + "/" + \
             account + '/' + \
             repo_name

--- a/nbinteract/pull_from_remote.py
+++ b/nbinteract/pull_from_remote.py
@@ -158,7 +158,7 @@ def _initialize_repo(repo_url, repo_dir, branch_name, config, progress=None):
     Clones repository and configures it to use sparse checkout.
     Extraneous folders will get removed later using git read-tree
     """
-    util.logger.info('Repo {} doesn\'t exist. Cloning...'.format(repo_name))
+    util.logger.info('Repo {} doesn\'t exist. Cloning...'.format(repo_url))
     # Clone repo
     repo = git.Repo.clone_from(
         repo_url,
@@ -172,7 +172,7 @@ def _initialize_repo(repo_url, repo_dir, branch_name, config, progress=None):
     config.set_value('core', 'sparsecheckout', True)
     config.release()
 
-    util.logger.info('Repo {} initialized'.format(repo_name))
+    util.logger.info('Repo {} initialized'.format(repo_url))
 
 
 DELETED_FILE_REGEX = re.compile(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="nbinteract",
-    version='0.0.22',
+    version='0.0.23',
     url="https://github.com/data-8/nbinteract",
     author="Data 8",
     description="Simple Jupyter extension to use interact.",


### PR DESCRIPTION
Closes #27.

After `$ export  ALLOWED_GITHUB_ACCOUNTS=data-8:tonyyanga`, the github account specification can be tested with this example url:

`/interact?account=tonyyanga&repo=android-ad&branch=master&path=README.md`