### PR TITLE
Fixed broken proceed link.

### DIFF
--- a/nbinteract/static/script.js
+++ b/nbinteract/static/script.js
@@ -4,7 +4,7 @@ function showProceedLink(proceed_url) {
     $(".proceed-link").html(proceed_url);
   } else  {
     var domain = document.domain;
-    $(".proceed-link").attr('href', domain);
+    $(".proceed-link").attr('href', "http://" + domain);
     $(".proceed-link").html("http://" + domain);
   }
   $(".proceed-container").show();


### PR DESCRIPTION
The datahub.berkeley.edu link on the following page is broken and leads to 404 error page. Prepending "http://" to `document.domain` fixes the issue, as the current link seems to be relative. 

![image](https://cloud.githubusercontent.com/assets/8205702/24032745/c32fbb4e-0aa6-11e7-8626-e8eb76e7a388.png)
