### PR TITLE
Fix slowness and erroring out when trying to reset files.

### DIFF
--- a/nbpuller/pull_from_remote.py
+++ b/nbpuller/pull_from_remote.py
@@ -1,5 +1,6 @@
 import os
 import re
+import urllib
 
 import git
 
@@ -142,8 +143,8 @@ def pull_from_remote(**kwargs):
         # Redirect to the final path given in the URL
         destination = os.path.join(notebook_path, repo_name, paths[-1].replace('*', ''))
         redirect_url = util.construct_path(config['GIT_REDIRECT_PATH'], {
-            'username': username,
-            'destination': destination,
+            'username': urllib.parse.quote_plus(username),
+            'destination': urllib.parse.quote_plus(destination),
         })
         util.logger.info('Redirecting to {}'.format(redirect_url))
         return messages.redirect(redirect_url)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="nbpuller",
-    version='0.1.8',
+    version='0.1.9',
     url="https://github.com/data-8/nbpuller",
     author="Data 8 @ UC Berkeley",
     description="Simple Jupyter extension to update files with remote git repository.",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     description="Simple Jupyter extension to update files with remote git repository.",
     packages=setuptools.find_packages(),
     install_requires=[
-        'notebook', 'pytest', 'webargs', 'requests', 'gitpython', 'toolz'
+        'notebook', 'pytest', 'webargs', 'requests', 'gitpython', 'toolz', 'urllib'
     ],
     package_data={'nbpuller': ['static/*']},
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     description="Simple Jupyter extension to update files with remote git repository.",
     packages=setuptools.find_packages(),
     install_requires=[
-        'notebook', 'pytest', 'webargs', 'requests', 'gitpython', 'toolz', 'urllib'
+        'notebook', 'pytest', 'webargs', 'requests', 'gitpython', 'toolz'
     ],
     package_data={'nbpuller': ['static/*']},
 )


### PR DESCRIPTION
@yuvipanda this fix should solve future `pathspec '<filename>' did not match any file(s) known to git.` errors.

- Speeds up resetting large amounts of files by reducing redundancies
- Does not error out when trying to checkout a file to reset it by explicitly setting the branch
- Fixes filenames not being escaped in the redirect url